### PR TITLE
Add basic Fabric server support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://jitpack.io")
     maven("https://repo.papermc.io/repository/maven-public/")
+    maven("https://maven.fabricmc.net/")
     maven {
         name = "papermc"
         url = uri("https://repo.papermc.io/repository/maven-public/")
@@ -43,6 +44,9 @@ dependencies {
     // velocity
     compileOnly("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
     annotationProcessor("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
+
+    // fabric
+    compileOnly("net.fabricmc:fabric-loader:0.16.14")
 
     implementation("io.vertx:vertx-core:$vertxVersion")
     implementation("io.vertx:vertx-web-client:$vertxVersion")
@@ -73,6 +77,10 @@ tasks.processResources {
     filesMatching("velocity-plugin.json") {
         expand(mapOf("version" to version))
     }
+
+    filesMatching("fabric.mod.json") {
+        expand(mapOf("version" to version))
+    }
 }
 
 tasks {
@@ -96,6 +104,11 @@ tasks {
             copy {
                 from(shadowJar.get().archiveFile.get().asFile.absolutePath)
                 into("../minecraft test servers/Folia/plugins")
+            }
+
+            copy {
+                from(shadowJar.get().archiveFile.get().asFile.absolutePath)
+                into("../minecraft test servers/Fabric/mods")
             }
         }
     }

--- a/src/main/kotlin/com/panomc/plugins/pano/core/ServerType.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/core/ServerType.kt
@@ -6,5 +6,6 @@ enum class ServerType {
     PAPER,
     SPIGOT,
     BUKKIT,
-    VELOCITY
+    VELOCITY,
+    FABRIC
 }

--- a/src/main/kotlin/com/panomc/plugins/pano/core/command/commands/PanoCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/core/command/commands/PanoCommand.kt
@@ -9,7 +9,7 @@ import java.io.Console
 class PanoCommand(
     private val platformManager: PlatformManager
 ) : com.panomc.plugins.pano.core.command.Command {
-    override val name: String = "Pano"
+    override val name: String = "pano"
     override val permission: String = "pano.admin"
     override val description: String = "Runs Pano commands."
     override val permissionMessage: String = "You do not have permission!"

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
@@ -7,10 +7,9 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
 import com.mojang.brigadier.context.CommandContext
 import com.panomc.plugins.pano.core.command.Command
 import com.panomc.plugins.pano.core.helper.CommandHelper
-import com.panomc.plugins.pano.core.helper.PanoPluginMain
 import kotlinx.coroutines.runBlocking
 
-class FabricCommand(private val command: Command, private val pluginMain: PanoPluginMain) : CommandHelper {
+class FabricCommand(private val command: Command) : CommandHelper {
     fun register(dispatcher: CommandDispatcher<Any>) {
         dispatcher.register(
             literal<Any>(command.name)
@@ -41,8 +40,7 @@ class FabricCommand(private val command: Command, private val pluginMain: PanoPl
                     java.util.function.Supplier::class.java.isAssignableFrom(it.parameterTypes[0])
             } ?: throw NoSuchMethodException("sendFeedback")
 
-            val colored = pluginMain.translateColor(message)
-            val textObj = FabricTextUtil.toText(colored)
+            val textObj = FabricTextUtil.toText(message)
             val supplier = java.util.function.Supplier { textObj }
             feedback.isAccessible = true
             feedback.invoke(source, supplier, false)

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
@@ -7,9 +7,10 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
 import com.mojang.brigadier.context.CommandContext
 import com.panomc.plugins.pano.core.command.Command
 import com.panomc.plugins.pano.core.helper.CommandHelper
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
 import kotlinx.coroutines.runBlocking
 
-class FabricCommand(private val command: Command) : CommandHelper {
+class FabricCommand(private val command: Command, private val pluginMain: PanoPluginMain) : CommandHelper {
     fun register(dispatcher: CommandDispatcher<Any>) {
         dispatcher.register(
             literal<Any>(command.name)
@@ -40,7 +41,8 @@ class FabricCommand(private val command: Command) : CommandHelper {
                     java.util.function.Supplier::class.java.isAssignableFrom(it.parameterTypes[0])
             } ?: throw NoSuchMethodException("sendFeedback")
 
-            val textObj = FabricTextUtil.toText(message)
+            val colored = pluginMain.translateColor(message)
+            val textObj = FabricTextUtil.toText(colored)
             val supplier = java.util.function.Supplier { textObj }
             feedback.isAccessible = true
             feedback.invoke(source, supplier, false)

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
@@ -29,31 +29,32 @@ class FabricCommand(private val command: Command, private val pluginMain: PanoPl
 
     override fun sendMessage(commandSender: Any, message: String) {
         try {
-            val resolver = net.fabricmc.loader.api.FabricLoader.getInstance().mappingResolver
-            val textClassName = resolver.mapClassName("named", "net.minecraft.text.Text")
-            val literalName = resolver.mapMethodName(
-                "named",
-                "net.minecraft.text.Text",
-                "literal",
-                "(Ljava/lang/String;)Lnet/minecraft/text/MutableText;"
-            )
-            val textClass = Class.forName(textClassName)
-            val literal = textClass.getMethod(literalName, String::class.java)
-
             val source = try {
                 commandSender.javaClass.getMethod("getSource").invoke(commandSender)
             } catch (_: NoSuchMethodException) {
                 commandSender
             }
-            val feedback = source.javaClass.getMethod(
-                "sendFeedback",
-                java.util.function.Supplier::class.java,
-                Boolean::class.javaPrimitiveType
-            )
 
-            val supplier = java.util.function.Supplier {
-                literal.invoke(null, pluginMain.translateColor(message))
-            }
+            val feedback = source.javaClass.methods.firstOrNull {
+                it.parameterCount == 2 &&
+                    it.parameterTypes[1] == Boolean::class.javaPrimitiveType &&
+                    java.util.function.Supplier::class.java.isAssignableFrom(it.parameterTypes[0])
+            } ?: throw NoSuchMethodException("sendFeedback")
+
+            val textClass = ((feedback.genericParameterTypes[0] as? java.lang.reflect.ParameterizedType)
+                ?.actualTypeArguments?.firstOrNull() as? Class<*>)
+                ?: throw ClassNotFoundException("Text class")
+
+            val literal = textClass.methods.firstOrNull { m ->
+                java.lang.reflect.Modifier.isStatic(m.modifiers) &&
+                    m.parameterCount == 1 &&
+                    m.parameterTypes[0] == String::class.java &&
+                    textClass.isAssignableFrom(m.returnType)
+            } ?: throw NoSuchMethodException("literal")
+
+            val textObj = literal.invoke(null, pluginMain.translateColor(message))
+            val supplier = java.util.function.Supplier { textObj }
+            feedback.isAccessible = true
             feedback.invoke(source, supplier, false)
         } catch (e: Exception) {
             e.printStackTrace()

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
@@ -29,8 +29,16 @@ class FabricCommand(private val command: Command, private val pluginMain: PanoPl
 
     override fun sendMessage(commandSender: Any, message: String) {
         try {
-            val textClass = Class.forName("net.minecraft.text.Text")
-            val literal = textClass.getMethod("literal", String::class.java)
+            val resolver = net.fabricmc.loader.api.FabricLoader.getInstance().mappingResolver
+            val textClassName = resolver.mapClassName("named", "net.minecraft.text.Text")
+            val literalName = resolver.mapMethodName(
+                "named",
+                "net.minecraft.text.Text",
+                "literal",
+                "(Ljava/lang/String;)Lnet/minecraft/text/MutableText;"
+            )
+            val textClass = Class.forName(textClassName)
+            val literal = textClass.getMethod(literalName, String::class.java)
 
             val source = try {
                 commandSender.javaClass.getMethod("getSource").invoke(commandSender)

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
@@ -32,7 +32,11 @@ class FabricCommand(private val command: Command, private val pluginMain: PanoPl
             val textClass = Class.forName("net.minecraft.text.Text")
             val literal = textClass.getMethod("literal", String::class.java)
 
-            val source = commandSender.javaClass.getMethod("getSource").invoke(commandSender)
+            val source = try {
+                commandSender.javaClass.getMethod("getSource").invoke(commandSender)
+            } catch (_: NoSuchMethodException) {
+                commandSender
+            }
             val feedback = source.javaClass.getMethod(
                 "sendFeedback",
                 java.util.function.Supplier::class.java,
@@ -43,8 +47,8 @@ class FabricCommand(private val command: Command, private val pluginMain: PanoPl
                 literal.invoke(null, pluginMain.translateColor(message))
             }
             feedback.invoke(source, supplier, false)
-        } catch (_: Exception) {
-            // ignore if Fabric classes are unavailable
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 }

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
@@ -1,0 +1,47 @@
+package com.panomc.plugins.pano.fabric
+
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
+import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
+import com.mojang.brigadier.context.CommandContext
+import com.panomc.plugins.pano.core.command.Command
+import com.panomc.plugins.pano.core.helper.CommandHelper
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+import kotlinx.coroutines.runBlocking
+
+class FabricCommand(private val command: Command, private val pluginMain: PanoPluginMain) : CommandHelper {
+    fun register(dispatcher: CommandDispatcher<Any>) {
+        dispatcher.register(
+            literal<Any>(command.name)
+                .executes { ctx -> execute(ctx) }
+                .then(argument<Any, String>("args", StringArgumentType.greedyString()).executes { ctx -> execute(ctx) })
+        )
+    }
+
+    private fun execute(context: CommandContext<Any>): Int {
+        val args = context.input.split(" ").drop(1).toTypedArray()
+        runBlocking {
+            command.handler(context.source, args, this@FabricCommand)
+        }
+        return 1
+    }
+
+    override fun sendMessage(commandSender: Any, message: String) {
+        try {
+            val textClass = Class.forName("net.minecraft.text.Text")
+            val literal = textClass.getMethod("literal", String::class.java)
+            val feedback = commandSender.javaClass.getMethod(
+                "sendFeedback",
+                java.util.function.Supplier::class.java,
+                Boolean::class.javaPrimitiveType
+            )
+            val supplier = java.util.function.Supplier {
+                literal.invoke(null, pluginMain.translateColor(message))
+            }
+            feedback.invoke(commandSender, supplier, false)
+        } catch (_: Exception) {
+            // ignore if Fabric classes are unavailable
+        }
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
@@ -31,15 +31,18 @@ class FabricCommand(private val command: Command, private val pluginMain: PanoPl
         try {
             val textClass = Class.forName("net.minecraft.text.Text")
             val literal = textClass.getMethod("literal", String::class.java)
-            val feedback = commandSender.javaClass.getMethod(
+
+            val source = commandSender.javaClass.getMethod("getSource").invoke(commandSender)
+            val feedback = source.javaClass.getMethod(
                 "sendFeedback",
                 java.util.function.Supplier::class.java,
                 Boolean::class.javaPrimitiveType
             )
+
             val supplier = java.util.function.Supplier {
                 literal.invoke(null, pluginMain.translateColor(message))
             }
-            feedback.invoke(commandSender, supplier, false)
+            feedback.invoke(source, supplier, false)
         } catch (_: Exception) {
             // ignore if Fabric classes are unavailable
         }

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricCommand.kt
@@ -7,10 +7,9 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder.argument
 import com.mojang.brigadier.context.CommandContext
 import com.panomc.plugins.pano.core.command.Command
 import com.panomc.plugins.pano.core.helper.CommandHelper
-import com.panomc.plugins.pano.core.helper.PanoPluginMain
 import kotlinx.coroutines.runBlocking
 
-class FabricCommand(private val command: Command, private val pluginMain: PanoPluginMain) : CommandHelper {
+class FabricCommand(private val command: Command) : CommandHelper {
     fun register(dispatcher: CommandDispatcher<Any>) {
         dispatcher.register(
             literal<Any>(command.name)
@@ -41,18 +40,7 @@ class FabricCommand(private val command: Command, private val pluginMain: PanoPl
                     java.util.function.Supplier::class.java.isAssignableFrom(it.parameterTypes[0])
             } ?: throw NoSuchMethodException("sendFeedback")
 
-            val textClass = ((feedback.genericParameterTypes[0] as? java.lang.reflect.ParameterizedType)
-                ?.actualTypeArguments?.firstOrNull() as? Class<*>)
-                ?: throw ClassNotFoundException("Text class")
-
-            val literal = textClass.methods.firstOrNull { m ->
-                java.lang.reflect.Modifier.isStatic(m.modifiers) &&
-                    m.parameterCount == 1 &&
-                    m.parameterTypes[0] == String::class.java &&
-                    textClass.isAssignableFrom(m.returnType)
-            } ?: throw NoSuchMethodException("literal")
-
-            val textObj = literal.invoke(null, pluginMain.translateColor(message))
+            val textObj = FabricTextUtil.toText(message)
             val supplier = java.util.function.Supplier { textObj }
             feedback.isAccessible = true
             feedback.invoke(source, supplier, false)

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
@@ -26,7 +26,8 @@ class FabricEventListener(
                     .forEach { it.handle(this, player) }
                 null
             }
-            joinEvent.javaClass.getMethod("register", joinInterface).invoke(joinEvent, joinProxy)
+            val joinRegister = joinEvent.javaClass.getMethod("register", Any::class.java)
+            joinRegister.invoke(joinEvent, joinProxy)
 
             val disconnectField = eventsClass.getField("DISCONNECT")
             val disconnectEvent = disconnectField.get(null)
@@ -38,7 +39,8 @@ class FabricEventListener(
                     .forEach { it.handle(this, player) }
                 null
             }
-            disconnectEvent.javaClass.getMethod("register", disconnectInterface).invoke(disconnectEvent, disconnectProxy)
+            val disconnectRegister = disconnectEvent.javaClass.getMethod("register", Any::class.java)
+            disconnectRegister.invoke(disconnectEvent, disconnectProxy)
         } catch (_: Exception) {
             // ignore if Fabric classes are unavailable
         }

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
@@ -3,12 +3,10 @@ package com.panomc.plugins.pano.fabric
 import com.panomc.plugins.pano.core.event.EventType
 import com.panomc.plugins.pano.core.event.Listener
 import com.panomc.plugins.pano.core.helper.EventHelper
-import com.panomc.plugins.pano.core.helper.PanoPluginMain
 import java.lang.reflect.Proxy
 import java.util.UUID
 
 class FabricEventListener(
-    private val pluginMain: PanoPluginMain,
     private val listeners: List<Listener>
 ) : EventHelper {
 
@@ -48,10 +46,8 @@ class FabricEventListener(
 
     override fun sendMessage(commandSender: Any, message: String) {
         try {
-            val textClass = Class.forName("net.minecraft.text.Text")
-            val literal = textClass.getMethod("literal", String::class.java)
-            val sendMessage = commandSender.javaClass.getMethod("sendMessage", textClass)
-            val text = literal.invoke(null, pluginMain.translateColor(message))
+            val sendMessage = commandSender.javaClass.getMethod("sendMessage", FabricTextUtil.TEXT_CLASS)
+            val text = FabricTextUtil.toText(message)
             sendMessage.invoke(commandSender, text)
         } catch (_: Exception) {
             // ignore

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
@@ -1,0 +1,69 @@
+package com.panomc.plugins.pano.fabric
+
+import com.panomc.plugins.pano.core.event.EventType
+import com.panomc.plugins.pano.core.event.Listener
+import com.panomc.plugins.pano.core.helper.EventHelper
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+import java.lang.reflect.Proxy
+import java.util.UUID
+
+class FabricEventListener(
+    private val pluginMain: PanoPluginMain,
+    private val listeners: List<Listener>
+) : EventHelper {
+
+    fun register() {
+        try {
+            val eventsClass = Class.forName("net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents")
+
+            val joinField = eventsClass.getField("JOIN")
+            val joinEvent = joinField.get(null)
+            val joinInterface = Class.forName("net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents\$Join")
+            val joinProxy = Proxy.newProxyInstance(joinInterface.classLoader, arrayOf(joinInterface)) { _, _, args ->
+                val handler = args[0]
+                val player = handler.javaClass.getMethod("getPlayer").invoke(handler)
+                listeners.filter { it.eventType == EventType.ON_PLAYER_JOIN }
+                    .forEach { it.handle(this, player) }
+                null
+            }
+            joinEvent.javaClass.getMethod("register", joinInterface).invoke(joinEvent, joinProxy)
+
+            val disconnectField = eventsClass.getField("DISCONNECT")
+            val disconnectEvent = disconnectField.get(null)
+            val disconnectInterface = Class.forName("net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents\$Disconnect")
+            val disconnectProxy = Proxy.newProxyInstance(disconnectInterface.classLoader, arrayOf(disconnectInterface)) { _, _, args ->
+                val handler = args[0]
+                val player = handler.javaClass.getMethod("getPlayer").invoke(handler)
+                listeners.filter { it.eventType == EventType.ON_PLAYER_DISCONNECT }
+                    .forEach { it.handle(this, player) }
+                null
+            }
+            disconnectEvent.javaClass.getMethod("register", disconnectInterface).invoke(disconnectEvent, disconnectProxy)
+        } catch (_: Exception) {
+            // ignore if Fabric classes are unavailable
+        }
+    }
+
+    override fun sendMessage(commandSender: Any, message: String) {
+        try {
+            val textClass = Class.forName("net.minecraft.text.Text")
+            val literal = textClass.getMethod("literal", String::class.java)
+            val sendMessage = commandSender.javaClass.getMethod("sendMessage", textClass)
+            val text = literal.invoke(null, pluginMain.translateColor(message))
+            sendMessage.invoke(commandSender, text)
+        } catch (_: Exception) {
+            // ignore
+        }
+    }
+
+    override fun convertToPlayerData(player: Any): EventHelper.Companion.PlayerData {
+        return try {
+            val uuid = player.javaClass.getMethod("getUuid").invoke(player) as UUID
+            val gameProfile = player.javaClass.getMethod("getGameProfile").invoke(player)
+            val username = gameProfile.javaClass.getMethod("getName").invoke(gameProfile) as String
+            EventHelper.Companion.PlayerData(uuid, username, 0L)
+        } catch (_: Exception) {
+            EventHelper.Companion.PlayerData(UUID.randomUUID(), "unknown", 0L)
+        }
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
@@ -3,10 +3,12 @@ package com.panomc.plugins.pano.fabric
 import com.panomc.plugins.pano.core.event.EventType
 import com.panomc.plugins.pano.core.event.Listener
 import com.panomc.plugins.pano.core.helper.EventHelper
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
 import java.lang.reflect.Proxy
 import java.util.UUID
 
 class FabricEventListener(
+    private val pluginMain: PanoPluginMain,
     private val listeners: List<Listener>
 ) : EventHelper {
 
@@ -47,7 +49,7 @@ class FabricEventListener(
     override fun sendMessage(commandSender: Any, message: String) {
         try {
             val sendMessage = commandSender.javaClass.getMethod("sendMessage", FabricTextUtil.TEXT_CLASS)
-            val text = FabricTextUtil.toText(message)
+            val text = FabricTextUtil.toText(pluginMain.translateColor(message))
             sendMessage.invoke(commandSender, text)
         } catch (_: Exception) {
             // ignore

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
@@ -3,12 +3,10 @@ package com.panomc.plugins.pano.fabric
 import com.panomc.plugins.pano.core.event.EventType
 import com.panomc.plugins.pano.core.event.Listener
 import com.panomc.plugins.pano.core.helper.EventHelper
-import com.panomc.plugins.pano.core.helper.PanoPluginMain
 import java.lang.reflect.Proxy
 import java.util.UUID
 
 class FabricEventListener(
-    private val pluginMain: PanoPluginMain,
     private val listeners: List<Listener>
 ) : EventHelper {
 
@@ -49,7 +47,7 @@ class FabricEventListener(
     override fun sendMessage(commandSender: Any, message: String) {
         try {
             val sendMessage = commandSender.javaClass.getMethod("sendMessage", FabricTextUtil.TEXT_CLASS)
-            val text = FabricTextUtil.toText(pluginMain.translateColor(message))
+            val text = FabricTextUtil.toText(message)
             sendMessage.invoke(commandSender, text)
         } catch (_: Exception) {
             // ignore

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricEventListener.kt
@@ -15,6 +15,8 @@ class FabricEventListener(
     fun register() {
         try {
             val eventsClass = Class.forName("net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents")
+            val eventInterface = Class.forName("net.fabricmc.fabric.api.event.Event")
+            val register = eventInterface.getMethod("register", Any::class.java)
 
             val joinField = eventsClass.getField("JOIN")
             val joinEvent = joinField.get(null)
@@ -26,8 +28,7 @@ class FabricEventListener(
                     .forEach { it.handle(this, player) }
                 null
             }
-            val joinRegister = joinEvent.javaClass.getMethod("register", Any::class.java)
-            joinRegister.invoke(joinEvent, joinProxy)
+            register.invoke(joinEvent, joinProxy)
 
             val disconnectField = eventsClass.getField("DISCONNECT")
             val disconnectEvent = disconnectField.get(null)
@@ -39,8 +40,7 @@ class FabricEventListener(
                     .forEach { it.handle(this, player) }
                 null
             }
-            val disconnectRegister = disconnectEvent.javaClass.getMethod("register", Any::class.java)
-            disconnectRegister.invoke(disconnectEvent, disconnectProxy)
+            register.invoke(disconnectEvent, disconnectProxy)
         } catch (_: Exception) {
             // ignore if Fabric classes are unavailable
         }

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -35,7 +35,7 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
             val callbackClass = Class.forName("net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback")
             val eventField = callbackClass.getField("EVENT")
             val eventInstance = eventField.get(null)
-            val registerMethod = eventInstance.javaClass.getMethod("register", callbackClass)
+            val registerMethod = eventInstance.javaClass.getMethod("register", Any::class.java)
             val proxy = java.lang.reflect.Proxy.newProxyInstance(
                 callbackClass.classLoader,
                 arrayOf(callbackClass)
@@ -45,8 +45,8 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
                 null
             }
             registerMethod.invoke(eventInstance, proxy)
-        } catch (e: Exception) {
-            logger.severe("Failed to register commands: ${e.message}")
+        } catch (e: Throwable) {
+            logger.log(java.util.logging.Level.SEVERE, "Failed to register commands", e)
         }
     }
 

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -54,7 +54,15 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
 
     override fun getServerData(): ServerData = serverData
 
-    override fun getPluginClassLoader(): URLClassLoader = FabricMain::class.java.classLoader as URLClassLoader
+    override fun getPluginClassLoader(): URLClassLoader {
+        val cl = FabricMain::class.java.classLoader
+        return if (cl is URLClassLoader) {
+            cl
+        } else {
+            val url = FabricMain::class.java.protectionDomain.codeSource.location
+            URLClassLoader(arrayOf(url), cl)
+        }
+    }
 
     override fun translateColor(text: String): String = text.replace("&", "§")
 

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -6,13 +6,13 @@ import com.panomc.plugins.pano.core.event.Listener
 import com.panomc.plugins.pano.core.helper.PanoPluginMain
 import com.panomc.plugins.pano.core.helper.ServerData
 import net.fabricmc.api.DedicatedServerModInitializer
-import com.panomc.plugins.pano.fabric.FabricTextUtil
 import java.io.File
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.logging.Level
 import java.util.logging.Logger
 
 class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
@@ -23,8 +23,28 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
     private val scheduledTasks = ConcurrentHashMap<() -> Unit, ScheduledFuture<*>>()
 
     override fun onInitializeServer() {
+        bindServerLifecycle()
         pano = Pano.init(this)
         pano.onServerStart()
+    }
+
+    private fun bindServerLifecycle() {
+        try {
+            val lifecycleClass = Class.forName("net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents")
+            val startedField = lifecycleClass.getField("SERVER_STARTED")
+            val eventInterface = Class.forName("net.fabricmc.fabric.api.event.Event")
+            val register = eventInterface.getMethod("register", Any::class.java)
+            val proxy = java.lang.reflect.Proxy.newProxyInstance(
+                lifecycleClass.classLoader,
+                arrayOf(lifecycleClass)
+            ) { _, _, args ->
+                serverData.bindServer(args[0])
+                null
+            }
+            register.invoke(startedField.get(null), proxy)
+        } catch (e: Exception) {
+            logger.log(Level.SEVERE, "Failed to hook server lifecycle", e)
+        }
     }
 
     override fun getDataFolder(): File = File("config/pano")
@@ -43,7 +63,7 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
                 arrayOf(callbackClass)
             ) { _, _, args ->
                 val dispatcher = args[0] as com.mojang.brigadier.CommandDispatcher<Any>
-                commands.forEach { FabricCommand(it).register(dispatcher) }
+                commands.forEach { FabricCommand(it, this@FabricMain).register(dispatcher) }
                 null
             }
             registerMethod.invoke(eventInstance, proxy)
@@ -85,7 +105,7 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
     override fun translateColor(text: String): String = FabricTextUtil.translateColorCodes(text)
 
     override fun registerEventListeners(listeners: List<Listener>) {
-        FabricEventListener(listeners).register()
+        FabricEventListener(this, listeners).register()
     }
 
     override fun unregisterEventListeners(listeners: List<Listener>) {

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -35,7 +35,8 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
             val callbackClass = Class.forName("net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback")
             val eventField = callbackClass.getField("EVENT")
             val eventInstance = eventField.get(null)
-            val registerMethod = eventInstance.javaClass.getMethod("register", Any::class.java)
+            val eventInterface = Class.forName("net.fabricmc.fabric.api.event.Event")
+            val registerMethod = eventInterface.getMethod("register", Any::class.java)
             val proxy = java.lang.reflect.Proxy.newProxyInstance(
                 callbackClass.classLoader,
                 arrayOf(callbackClass)

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -1,0 +1,68 @@
+package com.panomc.plugins.pano.fabric
+
+import com.panomc.plugins.pano.core.Pano
+import com.panomc.plugins.pano.core.command.Command
+import com.panomc.plugins.pano.core.event.Listener
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+import com.panomc.plugins.pano.core.helper.ServerData
+import net.fabricmc.api.DedicatedServerModInitializer
+import java.io.File
+import java.net.URLClassLoader
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+
+class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
+    private lateinit var pano: Pano
+    private val logger: Logger = Logger.getLogger("Pano")
+    private val serverData = FabricServerData()
+    private val scheduler = Executors.newScheduledThreadPool(1)
+    private val scheduledTasks = ConcurrentHashMap<() -> Unit, ScheduledFuture<*>>()
+
+    override fun onInitializeServer() {
+        pano = Pano.init(this)
+        pano.onServerStart()
+    }
+
+    override fun getDataFolder(): File = File("config/pano")
+
+    override fun getLogger(): Logger = logger
+
+    override fun registerCommands(commands: List<Command>) {
+        // Fabric command registration requires Minecraft classes; not implemented
+    }
+
+    override fun unregisterCommands(commands: List<Command>) {
+        // No-op for now
+    }
+
+    override fun registerSchedule(task: () -> Unit) {
+        stopSchedule(task)
+        val future = scheduler.scheduleAtFixedRate(task, 1, 1, TimeUnit.SECONDS)
+        scheduledTasks[task] = future
+    }
+
+    override fun stopSchedule(task: () -> Unit) {
+        scheduledTasks.remove(task)?.cancel(false)
+    }
+
+    override fun unregisterSchedules(tasks: List<() -> Unit>) {
+        tasks.forEach { stopSchedule(it) }
+    }
+
+    override fun getServerData(): ServerData = serverData
+
+    override fun getPluginClassLoader(): URLClassLoader = FabricMain::class.java.classLoader as URLClassLoader
+
+    override fun translateColor(text: String): String = text.replace("&", "§")
+
+    override fun registerEventListeners(listeners: List<Listener>) {
+        // Fabric events require Minecraft classes; not implemented
+    }
+
+    override fun unregisterEventListeners(listeners: List<Listener>) {
+        // No-op for now
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -31,7 +31,23 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
     override fun getLogger(): Logger = logger
 
     override fun registerCommands(commands: List<Command>) {
-        // Fabric command registration requires Minecraft classes; not implemented
+        try {
+            val callbackClass = Class.forName("net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback")
+            val eventField = callbackClass.getField("EVENT")
+            val eventInstance = eventField.get(null)
+            val registerMethod = eventInstance.javaClass.getMethod("register", callbackClass)
+            val proxy = java.lang.reflect.Proxy.newProxyInstance(
+                callbackClass.classLoader,
+                arrayOf(callbackClass)
+            ) { _, _, args ->
+                val dispatcher = args[0] as com.mojang.brigadier.CommandDispatcher<Any>
+                commands.forEach { FabricCommand(it, this).register(dispatcher) }
+                null
+            }
+            registerMethod.invoke(eventInstance, proxy)
+        } catch (e: Exception) {
+            logger.severe("Failed to register commands: ${e.message}")
+        }
     }
 
     override fun unregisterCommands(commands: List<Command>) {
@@ -67,7 +83,7 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
     override fun translateColor(text: String): String = text.replace("&", "§")
 
     override fun registerEventListeners(listeners: List<Listener>) {
-        // Fabric events require Minecraft classes; not implemented
+        FabricEventListener(this, listeners).register()
     }
 
     override fun unregisterEventListeners(listeners: List<Listener>) {

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -66,7 +66,7 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
                 arrayOf(callbackClass)
             ) { _, _, args ->
                 val dispatcher = args[0] as com.mojang.brigadier.CommandDispatcher<Any>
-                commands.forEach { FabricCommand(it, this@FabricMain).register(dispatcher) }
+                commands.forEach { FabricCommand(it).register(dispatcher) }
                 null
             }
             registerMethod.invoke(eventInstance, proxy)
@@ -108,7 +108,7 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
     override fun translateColor(text: String): String = FabricTextUtil.translateColorCodes(text)
 
     override fun registerEventListeners(listeners: List<Listener>) {
-        FabricEventListener(this, listeners).register()
+        FabricEventListener(listeners).register()
     }
 
     override fun unregisterEventListeners(listeners: List<Listener>) {

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -32,11 +32,14 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
         try {
             val lifecycleClass = Class.forName("net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents")
             val startedField = lifecycleClass.getField("SERVER_STARTED")
+            val callbackClass = Class.forName(
+                "net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents\$ServerStarted"
+            )
             val eventInterface = Class.forName("net.fabricmc.fabric.api.event.Event")
             val register = eventInterface.getMethod("register", Any::class.java)
             val proxy = java.lang.reflect.Proxy.newProxyInstance(
-                lifecycleClass.classLoader,
-                arrayOf(lifecycleClass)
+                callbackClass.classLoader,
+                arrayOf(callbackClass)
             ) { _, _, args ->
                 serverData.bindServer(args[0])
                 null

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricMain.kt
@@ -6,6 +6,7 @@ import com.panomc.plugins.pano.core.event.Listener
 import com.panomc.plugins.pano.core.helper.PanoPluginMain
 import com.panomc.plugins.pano.core.helper.ServerData
 import net.fabricmc.api.DedicatedServerModInitializer
+import com.panomc.plugins.pano.fabric.FabricTextUtil
 import java.io.File
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
@@ -42,7 +43,7 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
                 arrayOf(callbackClass)
             ) { _, _, args ->
                 val dispatcher = args[0] as com.mojang.brigadier.CommandDispatcher<Any>
-                commands.forEach { FabricCommand(it, this).register(dispatcher) }
+                commands.forEach { FabricCommand(it).register(dispatcher) }
                 null
             }
             registerMethod.invoke(eventInstance, proxy)
@@ -81,10 +82,10 @@ class FabricMain : DedicatedServerModInitializer, PanoPluginMain {
         }
     }
 
-    override fun translateColor(text: String): String = text.replace("&", "§")
+    override fun translateColor(text: String): String = FabricTextUtil.translateColorCodes(text)
 
     override fun registerEventListeners(listeners: List<Listener>) {
-        FabricEventListener(this, listeners).register()
+        FabricEventListener(listeners).register()
     }
 
     override fun unregisterEventListeners(listeners: List<Listener>) {

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricServerData.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricServerData.kt
@@ -74,10 +74,15 @@ class FabricServerData : ServerData {
         val srv = server ?: return 0
         return runCatching {
             val playerManager = srv.javaClass.getMethod("getPlayerManager").invoke(srv)
-            playerManager.javaClass.methods.firstOrNull { m ->
+            val method = playerManager.javaClass.methods.firstOrNull { m ->
                 m.parameterCount == 0 && m.returnType == Int::class.javaPrimitiveType &&
-                    m.name.contains("getMaxPlayerCount")
-            }?.invoke(playerManager) as? Int ?: 0
+                    (m.name.contains("getMaxPlayerCount") ||
+                        m.name.contains("getMaxPlayers") ||
+                        m.name.contains("getMaxPlayer"))
+            }
+            (method?.invoke(playerManager) as? Int)
+                ?: loadProperties().getProperty("max-players")?.toIntOrNull()
+                ?: 0
         }.getOrDefault(0)
     }
 }

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricServerData.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricServerData.kt
@@ -2,22 +2,82 @@ package com.panomc.plugins.pano.fabric
 
 import com.panomc.plugins.pano.core.ServerType
 import com.panomc.plugins.pano.core.helper.ServerData
+import net.fabricmc.loader.api.FabricLoader
+import java.io.File
 import java.net.InetAddress
+import java.util.Properties
 
+/**
+ * Fabric implementation of [ServerData].
+ *
+ * The Minecraft server instance is captured at runtime via Fabric's server
+ * lifecycle callback and stored locally so that server information can be
+ * queried reflectively without compile-time dependencies on Minecraft
+ * classes. Basic configuration such as host, port, motd and max player count
+ * are pulled from the standard `server.properties` file.
+ */
 class FabricServerData : ServerData {
+    @Volatile
+    private var server: Any? = null
+
+    fun bindServer(server: Any) {
+        this.server = server
+    }
+
     override fun serverName(): String = "Fabric"
 
-    override fun hostAddress(): String = InetAddress.getLocalHost().hostAddress
+    private fun loadProperties(): Properties {
+        val props = Properties()
+        runCatching {
+            File("server.properties").inputStream().use { props.load(it) }
+        }
+        return props
+    }
 
-    override fun motd(): String? = null
+    override fun hostAddress(): String {
+        val props = loadProperties()
+        val ip = props.getProperty("server-ip")
+        return ip?.takeIf { it.isNotBlank() } ?: InetAddress.getLocalHost().hostAddress
+    }
 
-    override fun port(): Int = 0
+    override fun motd(): String? = loadProperties().getProperty("motd")
+
+    override fun port(): Int = loadProperties().getProperty("server-port")?.toIntOrNull() ?: 0
 
     override fun serverType(): ServerType = ServerType.FABRIC
 
-    override fun serverVersion(): String = "Unknown"
+    override fun serverVersion(): String {
+        return runCatching {
+            FabricLoader.getInstance().getModContainer("minecraft").get().metadata.version.friendlyString
+        }.getOrElse { "Unknown" }
+    }
 
-    override fun playerCount(): Int = 0
+    override fun playerCount(): Int {
+        val srv = server ?: return 0
+        return runCatching {
+            val playerManager = srv.javaClass.getMethod("getPlayerManager").invoke(srv)
+            // try direct count method first
+            playerManager.javaClass.methods.firstOrNull { m ->
+                m.parameterCount == 0 && m.returnType == Int::class.javaPrimitiveType &&
+                    m.name.contains("getCurrentPlayerCount")
+            }?.invoke(playerManager) as? Int ?: run {
+                val listMethod = playerManager.javaClass.methods.firstOrNull { m ->
+                    m.parameterCount == 0 && List::class.java.isAssignableFrom(m.returnType)
+                }
+                val list = listMethod?.invoke(playerManager) as? List<*>
+                list?.size ?: 0
+            }
+        }.getOrDefault(0)
+    }
 
-    override fun maxPlayerCount(): Int = 0
+    override fun maxPlayerCount(): Int {
+        val srv = server ?: return 0
+        return runCatching {
+            val playerManager = srv.javaClass.getMethod("getPlayerManager").invoke(srv)
+            playerManager.javaClass.methods.firstOrNull { m ->
+                m.parameterCount == 0 && m.returnType == Int::class.javaPrimitiveType &&
+                    m.name.contains("getMaxPlayerCount")
+            }?.invoke(playerManager) as? Int ?: 0
+        }.getOrDefault(0)
+    }
 }

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricServerData.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricServerData.kt
@@ -1,0 +1,23 @@
+package com.panomc.plugins.pano.fabric
+
+import com.panomc.plugins.pano.core.ServerType
+import com.panomc.plugins.pano.core.helper.ServerData
+import java.net.InetAddress
+
+class FabricServerData : ServerData {
+    override fun serverName(): String = "Fabric"
+
+    override fun hostAddress(): String = InetAddress.getLocalHost().hostAddress
+
+    override fun motd(): String? = null
+
+    override fun port(): Int = 0
+
+    override fun serverType(): ServerType = ServerType.FABRIC
+
+    override fun serverVersion(): String = "Unknown"
+
+    override fun playerCount(): Int = 0
+
+    override fun maxPlayerCount(): Int = 0
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricTextUtil.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricTextUtil.kt
@@ -1,0 +1,42 @@
+package com.panomc.plugins.pano.fabric
+
+import net.fabricmc.loader.api.FabricLoader
+import net.fabricmc.loader.api.MappingResolver
+
+/**
+ * Utility for translating legacy color codes and creating Minecraft Text
+ * instances without compile-time Minecraft dependencies.
+ */
+object FabricTextUtil {
+    private val resolver: MappingResolver = FabricLoader.getInstance().mappingResolver
+
+    private val textClass: Class<*> by lazy {
+        Class.forName(resolver.mapClassName("intermediary", "net.minecraft.class_2561"))
+    }
+
+    private val ofMethod by lazy {
+        val name = resolver.mapMethodName(
+            "intermediary",
+            "net.minecraft.class_2561",
+            "method_30163",
+            "(Ljava/lang/String;)Lnet/minecraft/class_2561;"
+        )
+        textClass.getMethod(name, String::class.java)
+    }
+
+    /**
+     * Converts alternate color codes (using '&') to section sign codes.
+     */
+    fun translateColorCodes(text: String): String = text.replace("&", "§")
+
+    /**
+     * Creates a Minecraft Text instance from the provided string,
+     * translating legacy color codes before conversion.
+     */
+    fun toText(text: String): Any {
+        return ofMethod.invoke(null, translateColorCodes(text))
+    }
+
+    /** Exposes the resolved Text class for reflective calls. */
+    val TEXT_CLASS: Class<*> get() = textClass
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricTextUtil.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricTextUtil.kt
@@ -113,7 +113,7 @@ object FabricTextUtil {
             val start = i
             while (i < input.length && input[i] != '§') i++
             val segmentText = input.substring(start, i)
-            val segment = ofMethod.invoke(null, segmentText)
+            var segment = ofMethod.invoke(null, segmentText)
 
             val applied = mutableListOf<Enum<*>>()
             color?.let { applied.add(it) }
@@ -128,7 +128,14 @@ object FabricTextUtil {
                         it.parameterTypes[0].isArray &&
                         it.parameterTypes[0].componentType == formattingClass
                 }
-                formattedMethod?.invoke(segment, array)
+                // Some implementations of formatted() return a new instance
+                // rather than mutating the original text. Capture the return
+                // value to ensure styles are applied regardless of the
+                // underlying behavior.
+                formattedMethod?.let { method ->
+                    val formatted = method.invoke(segment, array)
+                    if (formatted != null) segment = formatted
+                }
             }
 
             result = if (result == null) {
@@ -136,11 +143,10 @@ object FabricTextUtil {
             } else {
                 val appendMethod = result.javaClass.methods.firstOrNull {
                     it.parameterCount == 1 &&
-                        it.parameterTypes[0] == textClass &&
-                        it.returnType == result.javaClass
+                        it.parameterTypes[0] == textClass
                 }
-                appendMethod?.invoke(result, segment)
-                result
+                val appended = appendMethod?.invoke(result, segment)
+                appended ?: result
             }
         }
 

--- a/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricTextUtil.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/fabric/FabricTextUtil.kt
@@ -19,24 +19,135 @@ object FabricTextUtil {
             "intermediary",
             "net.minecraft.class_2561",
             "method_30163",
-            "(Ljava/lang/String;)Lnet/minecraft/class_2561;"
+            "(Ljava/lang/String;)Lnet/minecraft/class_2561;",
         )
         textClass.getMethod(name, String::class.java)
     }
 
+    private val formattingClass: Class<*> by lazy {
+        Class.forName(resolver.mapClassName("intermediary", "net.minecraft.class_124"))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private val formattingEnum: Class<out Enum<*>>
+        get() = formattingClass as Class<out Enum<*>>
+
+    private fun enumConst(name: String): Enum<*> = java.lang.Enum.valueOf(formattingEnum, name)
+
+    private val colorMap = mapOf(
+        '0' to enumConst("BLACK"),
+        '1' to enumConst("DARK_BLUE"),
+        '2' to enumConst("DARK_GREEN"),
+        '3' to enumConst("DARK_AQUA"),
+        '4' to enumConst("DARK_RED"),
+        '5' to enumConst("DARK_PURPLE"),
+        '6' to enumConst("GOLD"),
+        '7' to enumConst("GRAY"),
+        '8' to enumConst("DARK_GRAY"),
+        '9' to enumConst("BLUE"),
+        'a' to enumConst("GREEN"),
+        'b' to enumConst("AQUA"),
+        'c' to enumConst("RED"),
+        'd' to enumConst("LIGHT_PURPLE"),
+        'e' to enumConst("YELLOW"),
+        'f' to enumConst("WHITE"),
+    )
+
+    private val formatMap = mapOf(
+        'k' to enumConst("OBFUSCATED"),
+        'l' to enumConst("BOLD"),
+        'm' to enumConst("STRIKETHROUGH"),
+        'n' to enumConst("UNDERLINE"),
+        'o' to enumConst("ITALIC"),
+    )
+
+    private val formatChars = (colorMap.keys + formatMap.keys + 'r').joinToString("")
+
     /**
      * Converts alternate color codes (using '&') to section sign codes.
      */
-    fun translateColorCodes(text: String): String = text.replace("&", "§")
+    fun translateColorCodes(text: String): String {
+        val builder = StringBuilder(text.length)
+        var i = 0
+        while (i < text.length) {
+            val c = text[i]
+            if (c == '&' && i + 1 < text.length && text[i + 1].lowercaseChar() in formatChars) {
+                builder.append('§').append(text[i + 1])
+                i += 2
+            } else {
+                builder.append(c)
+                i++
+            }
+        }
+        return builder.toString()
+    }
 
     /**
      * Creates a Minecraft Text instance from the provided string,
-     * translating legacy color codes before conversion.
+     * translating legacy color codes and applying formatting.
      */
     fun toText(text: String): Any {
-        return ofMethod.invoke(null, translateColorCodes(text))
+        val input = translateColorCodes(text)
+        var color: Enum<*>? = null
+        val formats = linkedSetOf<Enum<*>>()
+        var result: Any? = null
+        var i = 0
+        while (i < input.length) {
+            if (input[i] == '§' && i + 1 < input.length) {
+                val code = input[i + 1].lowercaseChar()
+                when {
+                    colorMap.containsKey(code) -> {
+                        color = colorMap[code]
+                        formats.clear()
+                    }
+                    formatMap.containsKey(code) -> formats.add(formatMap[code]!!)
+                    code == 'r' -> {
+                        color = null
+                        formats.clear()
+                    }
+                }
+                i += 2
+                continue
+            }
+
+            val start = i
+            while (i < input.length && input[i] != '§') i++
+            val segmentText = input.substring(start, i)
+            val segment = ofMethod.invoke(null, segmentText)
+
+            val applied = mutableListOf<Enum<*>>()
+            color?.let { applied.add(it) }
+            applied.addAll(formats)
+
+            if (applied.isNotEmpty()) {
+                val array = java.lang.reflect.Array.newInstance(formattingClass, applied.size) as Array<Any>
+                for (index in applied.indices) array[index] = applied[index]
+
+                val formattedMethod = segment.javaClass.methods.firstOrNull {
+                    it.parameterCount == 1 &&
+                        it.parameterTypes[0].isArray &&
+                        it.parameterTypes[0].componentType == formattingClass
+                }
+                formattedMethod?.invoke(segment, array)
+            }
+
+            result = if (result == null) {
+                segment
+            } else {
+                val appendMethod = result.javaClass.methods.firstOrNull {
+                    it.parameterCount == 1 &&
+                        it.parameterTypes[0] == textClass &&
+                        it.returnType == result.javaClass
+                }
+                appendMethod?.invoke(result, segment)
+                result
+            }
+        }
+
+        return result ?: ofMethod.invoke(null, "")
     }
 
     /** Exposes the resolved Text class for reflective calls. */
     val TEXT_CLASS: Class<*> get() = textClass
 }
+

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,11 +12,11 @@
     "sources": "https://github.com/PanoMC/pano-mc-plugin"
   },
   "license": "MIT",
-  "icon": "assets/modid/icon.png",
+  "icon": "assets/pano/icon.png",
   "environment": "server",
   "entrypoints": {
     "main": [
-      "com.example.ExampleMod"
+      "com.panomc.plugins.pano.fabric.FabricMain"
     ]
   },
   "depends": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
   "icon": "assets/pano/icon.png",
   "environment": "server",
   "entrypoints": {
-    "main": [
+    "server": [
       "com.panomc.plugins.pano.fabric.FabricMain"
     ]
   },


### PR DESCRIPTION
## Summary
- add Fabric main entrypoint and server data implementation
- add Fabric server type and update build config for Fabric loader
- configure Fabric mod metadata to load new entrypoint

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a1a4eeb26083338a8c035198b051fa