### PR TITLE
Add initial Forge platform skeleton

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,10 @@ tasks.processResources {
     filesMatching("velocity-plugin.json") {
         expand(mapOf("version" to version))
     }
+
+    filesMatching("META-INF/mods.toml") {
+        expand(mapOf("version" to version))
+    }
 }
 
 tasks {
@@ -96,6 +100,11 @@ tasks {
             copy {
                 from(shadowJar.get().archiveFile.get().asFile.absolutePath)
                 into("../minecraft test servers/Folia/plugins")
+            }
+
+            copy {
+                from(shadowJar.get().archiveFile.get().asFile.absolutePath)
+                into("../minecraft test servers/Forge/mods")
             }
         }
     }

--- a/src/main/kotlin/com/panomc/plugins/pano/core/ServerType.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/core/ServerType.kt
@@ -6,5 +6,6 @@ enum class ServerType {
     PAPER,
     SPIGOT,
     BUKKIT,
-    VELOCITY
+    VELOCITY,
+    FORGE
 }

--- a/src/main/kotlin/com/panomc/plugins/pano/forge/ForgeCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/forge/ForgeCommand.kt
@@ -1,0 +1,20 @@
+package com.panomc.plugins.pano.forge
+
+import com.panomc.plugins.pano.core.command.Command
+import com.panomc.plugins.pano.core.helper.CommandHelper
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Simplified command wrapper for Forge. Actual registration should
+ * be handled using Forge command APIs.
+ */
+class ForgeCommand(private val command: Command, private val pluginMain: PanoPluginMain) : CommandHelper {
+    fun execute(commandSender: Any, args: Array<String>): Boolean = runBlocking {
+        command.handler(commandSender, args, this@ForgeCommand)
+    }
+
+    override fun sendMessage(commandSender: Any, message: String) {
+        // Message sending should be implemented with Forge APIs.
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/forge/ForgeEventListener.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/forge/ForgeEventListener.kt
@@ -1,0 +1,34 @@
+package com.panomc.plugins.pano.forge
+
+import com.panomc.plugins.pano.core.event.EventType
+import com.panomc.plugins.pano.core.helper.EventHelper
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+import java.util.UUID
+
+/**
+ * Placeholder event listener for Forge. Real implementations should
+ * hook into Forge's event bus.
+ */
+class ForgeEventListener(
+    private val pluginMain: PanoPluginMain,
+    private val listeners: List<com.panomc.plugins.pano.core.event.Listener>
+) : EventHelper {
+    override fun sendMessage(commandSender: Any, message: String) {
+        // Implement message sending using Forge APIs.
+    }
+
+    override fun convertToPlayerData(player: Any): EventHelper.Companion.PlayerData =
+        EventHelper.Companion.PlayerData(
+            uuid = UUID.randomUUID(),
+            username = "unknown",
+            ping = 0
+        )
+
+    fun onPlayerJoin(player: Any) {
+        listeners.filter { it.eventType == EventType.ON_PLAYER_JOIN }.forEach { it.handle(this, player) }
+    }
+
+    fun onPlayerDisconnect(player: Any) {
+        listeners.filter { it.eventType == EventType.ON_PLAYER_DISCONNECT }.forEach { it.handle(this, player) }
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/forge/ForgeMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/forge/ForgeMain.kt
@@ -1,0 +1,80 @@
+package com.panomc.plugins.pano.forge
+
+import com.panomc.plugins.pano.core.Pano
+import com.panomc.plugins.pano.core.command.Command
+import com.panomc.plugins.pano.core.event.Listener
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+import com.panomc.plugins.pano.core.helper.ServerData
+import java.io.File
+import java.net.URLClassLoader
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+
+/**
+ * Basic skeleton implementation for Forge servers.
+ * Actual Forge event and command registration should be
+ * implemented using Forge APIs at runtime.
+ */
+class ForgeMain : PanoPluginMain {
+    private val logger: Logger = Logger.getLogger("Pano")
+    private lateinit var pano: Pano
+    private val commands = mutableListOf<Command>()
+    private val scheduledTasks = ConcurrentHashMap<() -> Unit, ScheduledFuture<*>>()
+    private val scheduler = Executors.newSingleThreadScheduledExecutor()
+    private val serverData by lazy { ForgeServerData() }
+
+    fun onServerStarting() {
+        pano = Pano.init(this)
+        pano.onServerStart()
+    }
+
+    fun onServerStopping() {
+        if (::pano.isInitialized) {
+            pano.disable()
+        }
+    }
+
+    override fun getDataFolder(): File = File("plugins/pano")
+
+    override fun getLogger(): Logger = logger
+
+    override fun registerCommands(commands: List<Command>) {
+        // Command registration should be handled with Forge APIs.
+        this.commands.addAll(commands)
+    }
+
+    override fun unregisterCommands(commands: List<Command>) {
+        // Forge does not currently support unregistering commands at runtime.
+        this.commands.removeAll(commands)
+    }
+
+    override fun registerSchedule(task: () -> Unit) {
+        scheduledTasks[task]?.cancel(false)
+        scheduledTasks[task] = scheduler.scheduleAtFixedRate(task, 1, 1, TimeUnit.SECONDS)
+    }
+
+    override fun stopSchedule(task: () -> Unit) {
+        scheduledTasks.remove(task)?.cancel(false)
+    }
+
+    override fun unregisterSchedules(tasks: List<() -> Unit>) {
+        tasks.forEach { stopSchedule(it) }
+    }
+
+    override fun getServerData(): ServerData = serverData
+
+    override fun getPluginClassLoader(): URLClassLoader = this::class.java.classLoader as URLClassLoader
+
+    override fun translateColor(text: String): String = text
+
+    override fun registerEventListeners(listeners: List<Listener>) {
+        // Forge event registration should be implemented via MinecraftForge.EVENT_BUS at runtime.
+    }
+
+    override fun unregisterEventListeners(listeners: List<Listener>) {
+        // No-op for now.
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/forge/ForgeServerData.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/forge/ForgeServerData.kt
@@ -1,0 +1,24 @@
+package com.panomc.plugins.pano.forge
+
+import com.panomc.plugins.pano.core.ServerType
+import com.panomc.plugins.pano.core.helper.ServerData
+
+/**
+ * Placeholder server data for Forge servers. Actual values should
+ * be provided through Forge server APIs at runtime.
+ */
+class ForgeServerData : ServerData {
+    override fun serverName(): String = "ForgeServer"
+
+    override fun motd(): String? = null
+
+    override fun port(): Int = 0
+
+    override fun serverType(): ServerType = ServerType.FORGE
+
+    override fun serverVersion(): String = "unknown"
+
+    override fun playerCount(): Int = 0
+
+    override fun maxPlayerCount(): Int = 0
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,8 @@
+modLoader="javafml"
+loaderVersion="[1,)"
+license="MIT"
+[[mods]]
+modId="pano"
+version="${version}"
+displayName="Pano"
+description="Pano cross-platform plugin"


### PR DESCRIPTION
## Summary
- extend `ServerType` to include Forge
- add placeholder Forge implementation and mod metadata
- expand build script for Forge resources and copying

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a1c0adb92c833396443007c82b8fe0