### PR TITLE
Add Nukkit platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Pano MC Plugin
 
-Pano MC plugin for Spigot/Bungee/PaperSpigot/Velocity.
+Pano MC plugin for Spigot/Bungee/PaperSpigot/Velocity/Nukkit.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ repositories {
         name = "papermc"
         url = uri("https://repo.papermc.io/repository/maven-public/")
     }
+    maven("https://repo.nukkitx.com/main")
 }
 
 dependencies {
@@ -43,6 +44,9 @@ dependencies {
     // velocity
     compileOnly("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
     annotationProcessor("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
+
+    // nukkit
+    compileOnly("com.github.NukkitX:Nukkit:master-SNAPSHOT")
 
     implementation("io.vertx:vertx-core:$vertxVersion")
     implementation("io.vertx:vertx-web-client:$vertxVersion")
@@ -73,6 +77,10 @@ tasks.processResources {
     filesMatching("velocity-plugin.json") {
         expand(mapOf("version" to version))
     }
+
+    filesMatching("nukkit.yml") {
+        expand(mapOf("version" to version))
+    }
 }
 
 tasks {
@@ -96,6 +104,11 @@ tasks {
             copy {
                 from(shadowJar.get().archiveFile.get().asFile.absolutePath)
                 into("../minecraft test servers/Folia/plugins")
+            }
+
+            copy {
+                from(shadowJar.get().archiveFile.get().asFile.absolutePath)
+                into("../minecraft test servers/Nukkit/plugins")
             }
         }
     }

--- a/src/main/kotlin/com/panomc/plugins/pano/core/ServerType.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/core/ServerType.kt
@@ -6,5 +6,6 @@ enum class ServerType {
     PAPER,
     SPIGOT,
     BUKKIT,
-    VELOCITY
+    VELOCITY,
+    NUKKIT
 }

--- a/src/main/kotlin/com/panomc/plugins/pano/nukkit/NukkitCommand.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/nukkit/NukkitCommand.kt
@@ -1,0 +1,28 @@
+package com.panomc.plugins.pano.nukkit
+
+import cn.nukkit.command.CommandSender
+import com.panomc.plugins.pano.core.command.Command
+import com.panomc.plugins.pano.core.helper.CommandHelper
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+import kotlinx.coroutines.runBlocking
+
+class NukkitCommand(private val command: Command, private val pluginMain: PanoPluginMain) :
+    cn.nukkit.command.Command(command.name), CommandHelper {
+
+    init {
+        description = command.description
+        usageMessage = command.usage
+        setPermission(command.permission)
+    }
+
+    override fun execute(sender: CommandSender, label: String, args: Array<out String>): Boolean {
+        return runBlocking {
+            command.handler(sender, args, this@NukkitCommand)
+            true
+        }
+    }
+
+    override fun sendMessage(commandSender: Any, message: String) {
+        (commandSender as CommandSender).sendMessage(pluginMain.translateColor(message))
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/nukkit/NukkitEventListener.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/nukkit/NukkitEventListener.kt
@@ -1,0 +1,48 @@
+package com.panomc.plugins.pano.nukkit
+
+import cn.nukkit.command.CommandSender
+import cn.nukkit.event.EventHandler
+import cn.nukkit.event.Listener
+import cn.nukkit.event.player.PlayerJoinEvent
+import cn.nukkit.event.player.PlayerQuitEvent
+import cn.nukkit.Player
+import com.panomc.plugins.pano.core.event.EventType
+import com.panomc.plugins.pano.core.helper.EventHelper
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+
+class NukkitEventListener(
+    private val pluginMain: PanoPluginMain,
+    private val listeners: List<com.panomc.plugins.pano.core.event.Listener>
+) : Listener, EventHelper {
+
+    override fun sendMessage(commandSender: Any, message: String) {
+        (commandSender as CommandSender).sendMessage(pluginMain.translateColor(message))
+    }
+
+    override fun convertToPlayerData(player: Any): EventHelper.Companion.PlayerData {
+        val playerInstance = player as Player
+        return EventHelper.Companion.PlayerData(
+            uuid = playerInstance.uniqueId,
+            username = playerInstance.name,
+            ping = playerInstance.ping.toLong()
+        )
+    }
+
+    @EventHandler
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        listeners
+            .filter { it.eventType == EventType.ON_PLAYER_JOIN }
+            .forEach { listener ->
+                listener.handle(this, event.player)
+            }
+    }
+
+    @EventHandler
+    fun onPlayerQuit(event: PlayerQuitEvent) {
+        listeners
+            .filter { it.eventType == EventType.ON_PLAYER_DISCONNECT }
+            .forEach { listener ->
+                listener.handle(this, event.player)
+            }
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/nukkit/NukkitMain.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/nukkit/NukkitMain.kt
@@ -1,0 +1,75 @@
+package com.panomc.plugins.pano.nukkit
+
+import cn.nukkit.plugin.PluginBase
+import cn.nukkit.utils.TextFormat
+import cn.nukkit.event.HandlerList
+import cn.nukkit.scheduler.TaskHandler
+import com.panomc.plugins.pano.core.Pano
+import com.panomc.plugins.pano.core.command.Command
+import com.panomc.plugins.pano.core.event.Listener
+import com.panomc.plugins.pano.core.helper.PanoPluginMain
+import com.panomc.plugins.pano.core.helper.ServerData
+import java.net.URLClassLoader
+
+class NukkitMain : PluginBase(), PanoPluginMain {
+    private lateinit var pano: Pano
+    private val commands = mutableListOf<NukkitCommand>()
+    private val scheduledTasks = mutableMapOf<() -> Unit, TaskHandler>()
+    private val serverData by lazy { NukkitServerData(this) }
+
+    override fun onEnable() {
+        pano = Pano.init(this)
+        pano.onServerStart()
+    }
+
+    override fun onDisable() {
+        if (::pano.isInitialized) {
+            pano.disable()
+        }
+    }
+
+    override fun registerCommands(commands: List<Command>) {
+        commands.map { NukkitCommand(it, this) }.forEach { cmd ->
+            this.commands.add(cmd)
+            server.commandMap.register(name, cmd)
+        }
+    }
+
+    override fun unregisterCommands(commands: List<Command>) {
+        this.commands.forEach { cmd ->
+            cmd.unregister(server.commandMap)
+        }
+        this.commands.clear()
+    }
+
+    override fun registerSchedule(task: () -> Unit) {
+        if (scheduledTasks.containsKey(task)) {
+            stopSchedule(task)
+        }
+        val handler = server.scheduler.scheduleRepeatingTask(this, Runnable { task.invoke() }, 20)
+        scheduledTasks[task] = handler
+    }
+
+    override fun stopSchedule(task: () -> Unit) {
+        scheduledTasks[task]?.cancel()
+        scheduledTasks.remove(task)
+    }
+
+    override fun unregisterSchedules(tasks: List<() -> Unit>) {
+        tasks.forEach { stopSchedule(it) }
+    }
+
+    override fun getServerData(): ServerData = serverData
+
+    override fun getPluginClassLoader(): URLClassLoader = javaClass.classLoader as URLClassLoader
+
+    override fun translateColor(text: String): String = TextFormat.colorize('&', text)
+
+    override fun registerEventListeners(listeners: List<Listener>) {
+        server.pluginManager.registerEvents(NukkitEventListener(this, listeners), this)
+    }
+
+    override fun unregisterEventListeners(listeners: List<Listener>) {
+        HandlerList.unregisterAll(this)
+    }
+}

--- a/src/main/kotlin/com/panomc/plugins/pano/nukkit/NukkitServerData.kt
+++ b/src/main/kotlin/com/panomc/plugins/pano/nukkit/NukkitServerData.kt
@@ -1,0 +1,23 @@
+package com.panomc.plugins.pano.nukkit
+
+import com.panomc.plugins.pano.core.ServerType
+import com.panomc.plugins.pano.core.helper.ServerData
+import cn.nukkit.plugin.PluginBase
+
+class NukkitServerData(private val plugin: PluginBase) : ServerData {
+    override fun serverName(): String = plugin.server.name
+
+    override fun hostAddress(): String = plugin.server.ip
+
+    override fun motd(): String? = plugin.server.motd
+
+    override fun port(): Int = plugin.server.port
+
+    override fun serverType(): ServerType = ServerType.NUKKIT
+
+    override fun serverVersion(): String = plugin.server.version
+
+    override fun playerCount(): Int = plugin.server.onlinePlayers.size
+
+    override fun maxPlayerCount(): Int = plugin.server.maxPlayers
+}

--- a/src/main/resources/nukkit.yml
+++ b/src/main/resources/nukkit.yml
@@ -1,0 +1,21 @@
+name: Pano
+main: com.panomc.plugins.pano.nukkit.NukkitMain
+version: ${version}
+author: Pano MC
+description: An advanced web platform for Minecraft servers.
+website: http://panomc.com
+api: ["1.0.0"]
+commands:
+  pano:
+    description: Runs Pano commands.
+    permission: pano.admin
+    permission-message: You do not have permission!
+permissions:
+  pano.admin:
+    description: Allows Pano command.
+    default: op
+  pano.*:
+    description: Allows everything in Pano.
+    default: op
+    children:
+      pano.admin: true


### PR DESCRIPTION
## Summary
- add Nukkit server support alongside Spigot, Bungeecord and Velocity
- include Nukkit plugin descriptor and Gradle config
- register Nukkit commands, events and scheduling

## Testing
- `./gradlew build --info` *(fails: Failed to get resource: GET. [HTTP HTTP/1.1 522 Unknown: https://repo.nukkitx.com/main/org/cloudburstmc/fastutil/maps/int-short-maps/8.5.15-SNAPSHOT/maven-metadata.xml)])*

------
https://chatgpt.com/codex/tasks/task_e_68a1c0d87460833380e7faa7b755e335